### PR TITLE
Fix build on latest nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703637592,
-        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
-        "path": "/nix/store/lf2dq57rqn8d03ybrxxi6l8gg27a4av0-source",
-        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
-        "type": "path"
+        "lastModified": 1756696532,
+        "narHash": "sha256-6FWagzm0b7I/IGigOv9pr6LL7NQ86mextfE8g8Q6HBg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "58dcbf1ec551914c3756c267b8b9c8c86baa1b2f",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/virtualkeyboard-adapter.nix
+++ b/virtualkeyboard-adapter.nix
@@ -9,6 +9,8 @@ stdenv.mkDerivation {
 
   src = ./.;
 
+  cmakeFlags = ["-DCMAKE_CXX_STANDARD=20"];
+
   nativeBuildInputs = [cmake];
   buildInputs = [fcitx5];
 }


### PR DESCRIPTION
After updating to latest nixos-unstable, I was getting compiling errors such as ` error: 'span' in namespace 'std' does not name a template type`.

I added a cmake flag to fix this. I'm not familiar with cmake so I don't know if there were changes to make outside of nix.